### PR TITLE
hotplug-dispatch: don't filter empty env variables

### DIFF
--- a/hotplug-dispatch.c
+++ b/hotplug-dispatch.c
@@ -241,9 +241,6 @@ static int hotplug_call(struct ubus_context *ctx, struct ubus_object *obj,
 			continue;
 		*tmp = '=';
 
-		if (!strlen(++tmp))
-			continue;
-
 		if (!strcmp(enve, "ASYNC=0"))
 			async = false;
 


### PR DESCRIPTION
Empty environment variables are a valid case and are needed to override (or remove) existing variables such as HOSTNAME.

Reported-by: Hartmut Birr <e9hack@gmail.com>