### PR TITLE
trace: use standard POSIX header for basename()

### DIFF
--- a/trace/trace.c
+++ b/trace/trace.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
-#include <string.h>
+#include <libgen.h>
 #include <syslog.h>
 #include <limits.h>
 


### PR DESCRIPTION
The musl libc only implements POSIX basename() but provided a GNU header kludge in <string.h>, which is removed in musl 1.2.5 [1]. Use the standard <libgen.h> header to avoid compilation errors like:
```
trace/trace.c: In function 'main':
trace/trace.c:435:64: error: implicit declaration of function 'basename'; did you mean 'rename'? [-Werror=implicit-function-declaration]
  435 | if (asprintf(&json, "/tmp/%s.%u.json", basename(*argv), child) < 0)
      |                                        ^~~~~~~~
      |                                        rename
cc1: all warnings being treated as errors
```
Link 1: https://git.musl-libc.org/cgit/musl/log/?qt=grep&q=basename

@blogic This change is related to https://github.com/openwrt/openwrt/pull/14802 and was tested therein.