### PR TITLE
inittab: fallback when multiple "console=" is detected

### DIFF
--- a/inittab.c
+++ b/inittab.c
@@ -192,7 +192,8 @@ static void askconsole(struct init_action *a)
 	 * is in the device tree
 	 */
 	tty = get_cmdline_val("console", line, sizeof(line));
-	if (tty == NULL) {
+	if (tty == NULL ||
+	    get_cmdline_val_offset("console", line, sizeof(line), 1)) {
 		if (dev_exist("console"))
 			tty = "console";
 		else

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -163,10 +163,10 @@ char *get_active_console(char *out, int len)
 	return NULL;
 }
 
-char* get_cmdline_val(const char* name, char* out, int len)
+char *get_cmdline_val_offset(const char *name, char *out, int len, int offset)
 {
 	char line[CMDLINE_SIZE + 1], *c, *sptr;
-	int fd = open("/proc/cmdline", O_RDONLY);
+	int i, fd = open("/proc/cmdline", O_RDONLY);
 	ssize_t r = read(fd, line, sizeof(line) - 1);
 	close(fd);
 
@@ -175,7 +175,7 @@ char* get_cmdline_val(const char* name, char* out, int len)
 
 	line[r] = 0;
 
-	for (c = strtok_r(line, " \t\n", &sptr); c;
+	for (i = 0, c = strtok_r(line, " \t\n", &sptr); c;
 			c = strtok_r(NULL, " \t\n", &sptr)) {
 		char *sep = strchr(c, '=');
 		if (sep == NULL)
@@ -185,6 +185,8 @@ char* get_cmdline_val(const char* name, char* out, int len)
 		if (strncmp(name, c, klen) || name[klen] != 0)
 			continue;
 
+		if (i++ < offset)
+			continue;
 		strncpy(out, &sep[1], len);
 		out[len-1] = 0;
 		return out;

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -51,8 +51,11 @@ int blobmsg_list_fill(struct blobmsg_list *list, void *data, int len, bool array
 void blobmsg_list_free(struct blobmsg_list *list);
 bool blobmsg_list_equal(struct blobmsg_list *l1, struct blobmsg_list *l2);
 void blobmsg_list_move(struct blobmsg_list *list, struct blobmsg_list *src);
-char *get_cmdline_val(const char *name, char *out, int len);
+char *get_cmdline_val_offset(const char *name, char *out, int len, int offset);
 char *get_active_console(char *out, int len);
+
+#define get_cmdline_val(name, out, len) \
+	get_cmdline_val_offset(name, out, len, 0)
 
 int patch_fd(const char *device, int fd, int flags);
 int patch_stdio(const char *device);


### PR DESCRIPTION
This patch series is required for providing dmesg output support on "SERIAL" port (ttyATH1) in addition to "SERVICE" (ttyS0) on ELECOM WAB-I1750-PS.

## example

  bootargs: ```console=ttyATH1,115200n8 console=ttyS0,115200n8```

- current:

  - Linux (/dev/console): ```ttyS0```
  - procd: ```ttyATH1```

- after changes:

  - Linux (/dev/console): ```ttyS0```
  - procd: ```ttyS0``` (from ```/dev/console```)