### PR TITLE
state: set_stdio: chdir back to / in case of failure

### DIFF
--- a/state.c
+++ b/state.c
@@ -48,11 +48,12 @@ static void set_stdio(const char* tty)
 	if (chdir("/dev") ||
 	    !freopen(tty, "r", stdin) ||
 	    !freopen(tty, "w", stdout) ||
-	    !freopen(tty, "w", stderr) ||
-	    chdir("/"))
+	    !freopen(tty, "w", stderr))
 		ERROR("failed to set stdio: %m\n");
 	else
 		fcntl(STDERR_FILENO, F_SETFL, fcntl(STDERR_FILENO, F_GETFL) | O_NONBLOCK);
+	if (chdir("/"))
+		ERROR("failed to change dir to /: %m\n");
 }
 
 static void set_console(void)


### PR DESCRIPTION
This has been previously posted to the mailinglist
* http://lists.openwrt.org/pipermail/openwrt-devel/2023-December/041910.html
* http://lists.openwrt.org/pipermail/openwrt-devel/2024-March/042435.html

------

set_stdio chdirs to /dev/ to facilitate easy freopen of the console device name given by the tty parameter. Make sure to chdir back to / in all cases, even in the error path. This keeps the function free from unintended side effects.

Before this commit, in case of an error, the working directory would remain /dev/ which would break sysupgrade because the rest of the code would rely on the current working directory to be unchanged, which is not an unreasonable expectation to make.

Fixing this fixes an issue where sysupgrade would fail, when /dev/console does not exist or cannot be opened, which can happen for example when setting console= on kernel cmdline.

Closes: https://github.com/openwrt/openwrt/issues/6005
Fixes: 91da63d3d3fd ("properly handle return codes")