### PR TITLE
Disable implicit controlling TTY.

### DIFF
--- a/inittab.c
+++ b/inittab.c
@@ -79,7 +79,7 @@ static int dev_exist(const char *dev)
 	if (dfd < 0)
 		return 0;
 
-	fd = openat(dfd, dev, O_RDONLY);
+	fd = openat(dfd, dev, O_RDONLY|O_NOCTTY);
 	close(dfd);
 
 	if (fd < 0)

--- a/state.c
+++ b/state.c
@@ -79,7 +79,7 @@ static void set_console(void)
 		return;
 	}
 	while (tty!=NULL) {
-		f = open(tty, O_RDONLY);
+		f = open(tty, O_RDONLY|O_NOCTTY);
 		if (f >= 0) {
 			close(f);
 			break;

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -203,6 +203,8 @@ int patch_fd(const char *device, int fd, int flags)
 {
 	int dfd, nfd;
 
+	flags |= O_NOCTTY;
+
 	if (device == NULL)
 		device = "/dev/null";
 


### PR DESCRIPTION
Disable the use of implicit controlling
TTYs. They will be enabled on demand.

This fixes a bug where 2 or more
consecutive Ctrl-C at the login prompt
triggers a reboot of the device.

Closes: https://github.com/openwrt/openwrt/issues/11306