### PR TITLE
init: increase kmodloader timeout

### DIFF
--- a/initd/init.c
+++ b/initd/init.c
@@ -152,7 +152,7 @@ main(int argc, char **argv)
 		const struct timespec req = {0, 10 * 1000 * 1000};
 		int i;
 
-		for (i = 0; i < 1200; i++) {
+		for (i = 0; i < 2000; i++) {
 			if (waitpid(pid, NULL, WNOHANG) > 0)
 				break;
 			nanosleep(&req, NULL);


### PR DESCRIPTION
Currently, the `init` process waits 12 seconds for the `kmodloader` process to load all kernel modules from `/etc/modules-boot.d/*` before moving on.

This timeout isn't long enough for a Mellanox Spectrum-2 Switch, which needs around 15 seconds to load all kernel modules from the directory.

This commit increases the timeout to 20 seconds.