### PR TITLE
jail: fix NULL-pointer dereference when connection to ubus failed

### DIFF
--- a/jail/jail.c
+++ b/jail/jail.c
@@ -2858,6 +2858,12 @@ int main(int argc, char **argv)
 	signals_init();
 
 	parent_ctx = ubus_connect(NULL);
+	if (!parent_ctx) {
+		ERROR("Connection to ubus failed\n");
+		ret = -ECONNREFUSED;
+		goto errout;
+	}
+
 	ubus_add_uloop(parent_ctx);
 
 	if (opts.ocibundle) {


### PR DESCRIPTION
I encountered this error months ago and saw it again today. I haven't verify it but I think it should be the right fix.

Exit when parent_ctx is a NULL pointer.

Fixes error:
```
[   68.255561] do_page_fault(): sending SIGSEGV to ujail for invalid read access from 00000036
[   68.264161] epc = 77d3c6e3 in libubox.so.20240329[77d38000+1f000]
[   68.270494] ra  = 555946e3 in ujail[55590000+14000]
```
GDB track:
```
Reading symbols from ujail...
(gdb) l*(0x46e3)
0x46e3 is in main (/home/db/owrt/staging_dir/target-mipsel_24kc_musl/usr/include/libubus.h:290). 285
286     const char *ubus_strerror(int error);
287
288     static inline void ubus_add_uloop(struct ubus_context *ctx)
289     {
290             uloop_fd_add(&ctx->sock, ULOOP_BLOCKING | ULOOP_READ);
291     }
292
293     /* call this for read events on ctx->sock.fd when not using uloop */
294     static inline void ubus_handle_event(struct ubus_context *ctx)

Reading symbols from libubox.so.20240329...
(gdb) l*(0x46e3)
0x46e3 is in uloop_fd_add (/home/db/owrt/build_dir/target-mipsel_24kc_musl/libubox-2024.03.29~eb9bcb64/uloop.c:243).
238             int ret;
239
240             if (!(flags & (ULOOP_READ | ULOOP_WRITE)))
241                     return uloop_fd_delete(sock);
242
243             if (!sock->registered && !(flags & ULOOP_BLOCKING)) {
244                     fl = fcntl(sock->fd, F_GETFL, 0);
245                     fl |= O_NONBLOCK;
246                     fcntl(sock->fd, F_SETFL, fl);
247             }
```