### PR TITLE
ubus: expose unix timestamp in ubus system call

### DIFF
--- a/system.c
+++ b/system.c
@@ -386,6 +386,7 @@ static int system_info(struct ubus_context *ctx, struct ubus_object *obj,
 	blob_buf_init(&b, 0);
 
 	blobmsg_add_u32(&b, "localtime", now + tm->tm_gmtoff);
+	blobmsg_add_u32(&b, "unixtime", now);
 
 #ifdef linux
 	blobmsg_add_u32(&b, "uptime",    info.uptime);


### PR DESCRIPTION
Expose the unix timestamp in the ubus system call. In case the local time is different from UTC, the ubus call gets the local time and the unix timestamp.

```
root@c82c2b100000:~# ubus call system info
{
	"localtime": 1741345176,
	"unixtime": 1741341576,
	"uptime": 528,
	"load": [
		64,
		21984,
		20096
	],
	"memory": {
		"total": 124801024,
		"free": 46555136,
		"shared": 159744,
		"buffered": 53248,
		"available": 39346176,
		"cached": 33030144
	},
	"root": {
		"total": 1280,
		"free": 200,
		"used": 1080,
		"avail": 200
	},
	"tmp": {
		"total": 60936,
		"free": 60780,
		"used": 156,
		"avail": 60780
	},
	"swap": {
		"total": 0,
		"free": 0
	}
}
```
