### PR TITLE
hotplug-dispatch: redirect output to /dev/null

### DIFF
--- a/hotplug-dispatch.c
+++ b/hotplug-dispatch.c
@@ -33,6 +33,7 @@
 #include <libubus.h>
 
 #include "procd.h"
+#include "utils/utils.h"
 
 #define HOTPLUG_BASEDIR "/etc/hotplug.d"
 #define HOTPLUG_OBJECT_PREFIX "hotplug."
@@ -120,7 +121,10 @@ static void hotplug_exec(struct uloop_timeout *t)
 	pc->process.pid = fork();
 	if (pc->process.pid == 0) {
 		/* child */
-		exit(execve(exec_argv[0], exec_argv, pc->envp));
+		patch_stdio("/dev/null");
+		execve(exec_argv[0], exec_argv, pc->envp);
+		ERROR("Failed to execute script: %m\n");
+		exit(EXIT_FAILURE);
 	} else if (pc->process.pid < 0) {
 		/* fork error */
 		free(script);


### PR DESCRIPTION
@dangowrt 
During the hotplug call via the procd, a list is first created with the files in the hotplug.d directory. After that the scripts are then executed in lexical order. However, if a script is deleted after the list has been created, the following message is displayed on the tty console.

Command failed: Not found
/bin/sh: .: line 1: can't open '/etc/hotplug.d/ntp/25-travelmate_ntp': No such file or directory

So that the message is not displayed in the tty console the 'stderr' must be redirected to '/dev/null'.