### PR TITLE
Fix/service watchdog handling

### DIFF
--- a/service/instance.c
+++ b/service/instance.c
@@ -1040,10 +1040,10 @@ instance_config_changed(struct service_instance *in, struct service_instance *in
 	if (in->jail.flags != in_new->jail.flags)
 		return true;
 
-	if (in->watchdog.mode != in_new->watchdog.mode)
+	if (!in->watchdog.self_managed && in->watchdog.mode != in_new->watchdog.mode)
 		return true;
 
-	if (in->watchdog.freq != in_new->watchdog.freq)
+	if (!in->watchdog.self_managed && in->watchdog.freq != in_new->watchdog.freq)
 		return true;
 
 	return false;
@@ -1517,9 +1517,11 @@ instance_config_move(struct service_instance *in, struct service_instance *in_sr
 	in->respawn_timeout = in_src->respawn_timeout;
 	in->reload_signal = in_src->reload_signal;
 	in->term_timeout = in_src->term_timeout;
-	in->watchdog.mode = in_src->watchdog.mode;
-	in->watchdog.freq = in_src->watchdog.freq;
-	// Note: in->watchdog.timeout is in a linked list; do not copy
+	if (!in->watchdog.self_managed) {
+		// Note: in->watchdog.timeout is in a linked list; do not copy
+		in->watchdog.mode = in_src->watchdog.mode;
+		in->watchdog.freq = in_src->watchdog.freq;
+	}
 	in->name = in_src->name;
 	in->nice = in_src->nice;
 	in->trace = in_src->trace;

--- a/service/instance.h
+++ b/service/instance.h
@@ -55,6 +55,7 @@ typedef enum instance_watchdog {
 } instance_watchdog_mode_t;
 
 struct watchdog {
+	bool self_managed;
 	instance_watchdog_mode_t mode;
 	uint32_t freq;
 	struct uloop_timeout timeout;

--- a/service/service.c
+++ b/service/service.c
@@ -1059,6 +1059,11 @@ service_handle_watchdog(struct ubus_context *ctx, struct ubus_object *obj,
 
 	ubus_send_reply(ctx, req, b.head);
 
+	// If the service adjusts the mode or timeout, mark it as self managed
+	// so that it doesn't get restarted with a new /etc/init.d/SERVICE start
+	if (tb[SERVICE_WATCHDOG_MODE] || tb[SERVICE_WATCHDOG_TIMEOUT])
+		in->watchdog.self_managed = true;
+
 	return UBUS_STATUS_OK;
 }
 


### PR DESCRIPTION
There are a couple of commits in this series - notably the first one fixes a crash in procd that occurs if a service is using a watchdog and you invoke `/etc/init.d/SERVICENAME start` while it's already started.

The second commit in the series fixes more of an annoyance than anything else.  There's a separate API call to manage the watchdog for a running service, like petting the watchdog.  It supports adjusting the watchdog parameters away from what the init script set.  Presumably if that was used, any of the initial startup settings in the init script are mainly to guard against the starting up of the daemon instead of guarding the runtime.  This simply marks a "self_managed" attribute when this occurs, and ignores that as a configuration changed when/if that occurs.