### PR TITLE
Improve instance dump for `jail`

### DIFF
--- a/service/instance.c
+++ b/service/instance.c
@@ -1764,7 +1764,6 @@ void instance_dump(struct blob_buf *b, struct service_instance *in, int verbose)
 			blobmsg_add_u8(b, "immediately", in->immediately);
 		}
 		blobmsg_add_u8(b, "console", (in->console.fd.fd > -1));
-		blobmsg_close_table(b, r);
 		if (!avl_is_empty(&in->jail.mount.avl)) {
 			struct blobmsg_list_node *var;
 			void *e = blobmsg_open_table(b, "mount");
@@ -1780,6 +1779,7 @@ void instance_dump(struct blob_buf *b, struct service_instance *in, int verbose)
 				blobmsg_add_blob(b, var->data);
 			blobmsg_close_array(b, s);
 		}
+		blobmsg_close_table(b, r);
 	}
 
 	if (in->extroot)

--- a/service/instance.c
+++ b/service/instance.c
@@ -1780,7 +1780,6 @@ void instance_dump(struct blob_buf *b, struct service_instance *in, int verbose)
 			blobmsg_add_u8(b, "immediately", in->immediately);
 		}
 		blobmsg_add_u8(b, "console", (in->console.fd.fd > -1));
-		blobmsg_close_table(b, r);
 		if (!avl_is_empty(&in->jail.mount.avl)) {
 			struct blobmsg_list_node *var;
 			void *e = blobmsg_open_table(b, "mount");
@@ -1796,6 +1795,7 @@ void instance_dump(struct blob_buf *b, struct service_instance *in, int verbose)
 				blobmsg_add_blob(b, var->data);
 			blobmsg_close_array(b, s);
 		}
+		blobmsg_close_table(b, r);
 	}
 
 	if (in->extroot)


### PR DESCRIPTION
`mount` and `setns` properties apply exclusively to `jail` data.
But in instance dump they are displayed as if they relate directly to the instance properties:

```sh
$ ubus call service list '{"name": "sysntpd"}'
{
        "sysntpd": {
                "instances": {
                        "instance1": {
                                "running": true,
                                "pid": 7405,
                                "command": [
                                        "/usr/sbin/ntpd",
                                        "-n",
                                        "-N",
                                        "-S",
                                        "/usr/sbin/ntpd-hotplug",
                                        "-p",
                                        "0.openwrt.pool.ntp.org",
                                        "-p",
                                        "1.openwrt.pool.ntp.org",
                                        "-p",
                                        "2.openwrt.pool.ntp.org",
                                        "-p",
                                        "3.openwrt.pool.ntp.org"
                                ],
                                "term_timeout": 5,
                                "respawn": {
                                        "threshold": 3600,
                                        "timeout": 5,
                                        "retry": 5
                                },
                                "no_new_privs": true,
                                "capabilities": "/etc/capabilities/ntpd.json",
                                "user": "ntp",
                                "group": "ntp",
                                "jail": {
                                        "name": "ntpd",
                                        "procfs": false,
                                        "sysfs": false,
                                        "ubus": true,
                                        "log": false,
                                        "ronly": false,
                                        "netns": false,
                                        "userns": false,
                                        "cgroupsns": false,
                                        "console": false
                                },
                                "mount": {
                                        "/bin/ubus": "0",
                                        "/usr/bin/env": "0",
                                        "/usr/bin/jshn": "0",
                                        "/usr/sbin/ntpd-hotplug": "0",
                                        "/usr/share/libubox/jshn.sh": "0"
                                }
                        }
                }
        }
}