### PR TITLE
signal: handle SIGUSR1 as halt

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -43,6 +43,9 @@ static void signal_shutdown(int signal, siginfo_t *siginfo, void *data)
 		msg = "reboot";
 		break;
 	case SIGUSR1:
+		event = RB_HALT_SYSTEM;
+		msg = "halt";
+		break;
 	case SIGUSR2:
 	case SIGPWR:
 		event = RB_POWER_OFF;


### PR DESCRIPTION
The SIGUSR1 (10) signal sent from BusyBox halt is for halt, so set the RB_HALT_SYSTEM to event instead of RB_POWER_OFF for system call.

tested on: Check Point V-80

before:

```
root@OpenWrt:~# halt
root@OpenWrt:~# [   55.589351] mv88e6085 f212a200.mdio-mii:00 lan1: left allmulticast mode
[   55.596066] mv88e6085 f212a200.mdio-mii:00 lan1: left promiscuous mode
[   55.602718] br-lan: port 1(lan1) entered disabled state
[   55.728484] mv88e6085 f212a200.mdio-mii:00 lan2: left allmulticast mode
[   55.735210] mv88e6085 f212a200.mdio-mii:00 lan2: left promiscuous mode
[   55.741936] br-lan: port 2(lan2) entered disabled state
[   55.867329] mv88e6085 f212a200.mdio-mii:00 lan3: left allmulticast mode
[   55.874049] mv88e6085 f212a200.mdio-mii:00 lan3: left promiscuous mode
[   55.880766] br-lan: port 3(lan3) entered disabled state
[   56.000789] mv88e6085 f212a200.mdio-mii:00 lan4: left allmulticast mode
[   56.007509] mv88e6085 f212a200.mdio-mii:00 lan4: left promiscuous mode
[   56.014173] br-lan: port 4(lan4) entered disabled state
[   56.130604] mv88e6085 f212a200.mdio-mii:00 lan5: left allmulticast mode
[   56.137329] mvpp2 f2000000.ethernet eth0: left allmulticast mode
[   56.143494] mv88e6085 f212a200.mdio-mii:00 lan5: left promiscuous mode
[   56.150087] mvpp2 f2000000.ethernet eth0: left promiscuous mode
[   56.156808] br-lan: port 5(lan5) entered disabled state
[   56.195808] mvpp2 f2000000.ethernet eth0: Link is Down
[   56.674393] mvpp2 f2000000.ethernet eth1: Link is Down
[   60.710177] reboot: __do_sys_reboot: cmd=0x4321fedc
[   60.817287] reboot: Power down
ERROR:   a8k_system_off:  needs to be implemented
PANIC in EL3 at x30 = 0x000000000402320c
x0 =            0x0000000000000000
x1 =            0x00000000f0512000
x2 =            0x0000000000000060
x3 =            0x0000000000000000
x4 =            0x00000000040290f8
x5 =            0x0000000000000000
x6 =            0x0000000004029090
x7 =            0x0000000000000001
x8 =            0x0000000000000001
x9 =            0x0000000000000001
x10 =           0x0000000000000040
x11 =           0x000000000402e090
x12 =           0x000000000402f640
x13 =           0x00000000ffffffea
x14 =           0x0000000004031934
x15 =           0x0000000004027a84
x16 =           0x00000000800000c5
x17 =           0xffffffc080020c94
x18 =           0x0000000000000731
x19 =           0x0000000004031000
x20 =           0x00000000fffffffe
x21 =           0x0000000000000000
x22 =           0x0000000000000000
x23 =           0x000000004321fedc
x24 =           0x0000000000000000
x25 =           0x0000000000000000
x26 =           0x0000000000000000
x27 =           0x0000000000000000
x28 =           0xffffff8002707000
x29 =           0x000000000402f5e0
scr_el3 =               0x0000000000000731
sctlr_el3 =             0x0000000030cd183b
cptr_el3 =              0x0000000000000000
tcr_el3 =               0x0000000080803520
daif =          0x00000000000002c0
mair_el3 =              0x00000000004404ff
spsr_el3 =              0x00000000800000c5
elr_el3 =               0xffffffc080020c94
ttbr0_el3 =             0x00000000040318e0
esr_el3 =               0x000000005e000000
far_el3 =               0x0000000000000000
spsr_el1 =              0x0000000040000005
elr_el1 =               0xffffffc0809130a4
spsr_abt =              0x0000000000000000
spsr_und =              0x0000000000000000
spsr_irq =              0x0000000000000000
spsr_fiq =              0x0000000000000000
sctlr_el1 =             0x0000000034d4d91d
actlr_el1 =             0x0000000000000000
cpacr_el1 =             0x0000000000300000
csselr_el1 =            0x0000000000000000
sp_el1 =                0xffffffc084fc3bd0
esr_el1 =               0x0000000056000000
ttbr0_el1 =             0x0000000007bc0000
ttbr1_el1 =             0x0000000007bc1000
mair_el1 =              0x000000040044ffff
amair_el1 =             0x0000000000000000
cpuectlr_el1 =          0x0000001b00000040
cpumerrsr_el1 =         0x0000000000000000
l2merrsr_el1 =          0x0000000000000000
```

after:

```
root@OpenWrt:~# halt
root@OpenWrt:~# [   37.125006] mv88e6085 f212a200.mdio-mii:00 lan1: left allmulticast mode
[   37.131669] mv88e6085 f212a200.mdio-mii:00 lan1: left promiscuous mode
[   37.138325] br-lan: port 1(lan1) entered disabled state
[   37.259064] mv88e6085 f212a200.mdio-mii:00 lan2: left allmulticast mode
[   37.265796] mv88e6085 f212a200.mdio-mii:00 lan2: left promiscuous mode
[   37.272464] br-lan: port 2(lan2) entered disabled state
[   37.395221] mv88e6085 f212a200.mdio-mii:00 lan3: left allmulticast mode
[   37.401937] mv88e6085 f212a200.mdio-mii:00 lan3: left promiscuous mode
[   37.408647] br-lan: port 3(lan3) entered disabled state
[   37.530554] mv88e6085 f212a200.mdio-mii:00 lan4: left allmulticast mode
[   37.537269] mv88e6085 f212a200.mdio-mii:00 lan4: left promiscuous mode
[   37.544007] br-lan: port 4(lan4) entered disabled state
[   37.664588] mv88e6085 f212a200.mdio-mii:00 lan5: left allmulticast mode
[   37.671303] mvpp2 f2000000.ethernet eth0: left allmulticast mode
[   37.677468] mv88e6085 f212a200.mdio-mii:00 lan5: left promiscuous mode
[   37.684049] mvpp2 f2000000.ethernet eth0: left promiscuous mode
[   37.690605] br-lan: port 5(lan5) entered disabled state
[   37.727395] mvpp2 f2000000.ethernet eth0: Link is Down
[   38.192654] mvpp2 f2000000.ethernet eth1: Link is Down
[   42.233985] reboot: __do_sys_reboot: cmd=0xcdef0123
[   42.314737] reboot: System halted
```