### PR TITLE
jail: mount ucode related bits into netifd jail

### DIFF
--- a/jail/jail.c
+++ b/jail/jail.c
@@ -2043,7 +2043,7 @@ static const struct blobmsg_policy oci_devices_policy[] = {
 	[OCI_DEVICES_MINOR] = { "minor", BLOBMSG_TYPE_INT32 },
 	[OCI_DEVICES_FILEMODE] = { "fileMode", BLOBMSG_TYPE_INT32 },
 	[OCI_DEVICES_UID] = { "uid", BLOBMSG_TYPE_INT32 },
-	[OCI_DEVICES_GID] = { "uid", BLOBMSG_TYPE_INT32 },
+	[OCI_DEVICES_GID] = { "gid", BLOBMSG_TYPE_INT32 },
 };
 
 static mode_t resolve_devtype(char *tstr)

--- a/jail/jail.c
+++ b/jail/jail.c
@@ -587,7 +587,7 @@ static struct mknod_args default_devices[] = {
 	{ .path = "/dev/full", .mode = (S_IFCHR|S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH), .dev = makedev(1, 7) },
 	{ .path = "/dev/random", .mode = (S_IFCHR|S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH), .dev = makedev(1, 8) },
 	{ .path = "/dev/urandom", .mode = (S_IFCHR|S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH), .dev = makedev(1, 9) },
-	{ .path = "/dev/tty", .mode = (S_IFCHR|S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP), .dev = makedev(5, 0), .gid = 5 },
+	{ .path = "/dev/tty", .mode = (S_IFCHR|S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH), .dev = makedev(5, 0), .gid = 5 },
 	{ 0 },
 };
 

--- a/jail/netifd.c
+++ b/jail/netifd.c
@@ -272,15 +272,18 @@ static void run_netifd(struct uloop_timeout *t)
 	blobmsg_add_string(&req, "/lib/netifd", "0");
 	blobmsg_add_string(&req, "/lib/network", "0");
 	blobmsg_add_string(&req, "/usr/bin/awk", "0");
+	blobmsg_add_string(&req, "/usr/bin/cut", "0");
+	blobmsg_add_string(&req, "/usr/bin/jshn", "0");
 	blobmsg_add_string(&req, "/usr/bin/killall", "0");
 	blobmsg_add_string(&req, "/usr/bin/logger", "0");
-	blobmsg_add_string(&req, "/usr/bin/jshn", "0");
+	blobmsg_add_string(&req, "/usr/bin/md5sum", "0");
 	blobmsg_add_string(&req, "/usr/bin/ucode", "0");
 	blobmsg_add_string(&req, "/usr/lib/ucode", "0");
 	blobmsg_add_string(&req, "/usr/share/libubox/jshn.sh", "0");
 	blobmsg_add_string(&req, "/usr/share/schema", "0");
 	blobmsg_add_string(&req, "/usr/share/ucode/wifi", "0");
 	blobmsg_add_string(&req, "/sbin/hotplug-call", "0");
+	blobmsg_add_string(&req, "/sbin/uci", "0");
 	blobmsg_add_string(&req, "/sbin/udhcpc", "0");
 	blobmsg_close_table(&req, mount);
 

--- a/jail/netifd.c
+++ b/jail/netifd.c
@@ -275,7 +275,11 @@ static void run_netifd(struct uloop_timeout *t)
 	blobmsg_add_string(&req, "/usr/bin/killall", "0");
 	blobmsg_add_string(&req, "/usr/bin/logger", "0");
 	blobmsg_add_string(&req, "/usr/bin/jshn", "0");
+	blobmsg_add_string(&req, "/usr/bin/ucode", "0");
+	blobmsg_add_string(&req, "/usr/lib/ucode", "0");
 	blobmsg_add_string(&req, "/usr/share/libubox/jshn.sh", "0");
+	blobmsg_add_string(&req, "/usr/share/schema", "0");
+	blobmsg_add_string(&req, "/usr/share/ucode/wifi", "0");
 	blobmsg_add_string(&req, "/sbin/hotplug-call", "0");
 	blobmsg_add_string(&req, "/sbin/udhcpc", "0");
 	blobmsg_close_table(&req, mount);

--- a/service/instance.c
+++ b/service/instance.c
@@ -759,7 +759,7 @@ instance_console(struct ustream *s, int bytes)
 		if (!buf)
 			break;
 
-		ulog(LOG_INFO, "out: %s\n", buf);
+		DEBUG(LOG_INFO, "out: %s\n", buf);
 
 		/* test if console client is attached */
 		if (in->console_client.fd.fd > -1)
@@ -781,7 +781,7 @@ instance_console_client(struct ustream *s, int bytes)
 		if (!buf)
 			break;
 
-		ulog(LOG_INFO, "in: %s\n", buf);
+		DEBUG(LOG_INFO, "in: %s\n", buf);
 		ustream_write(&in->console.stream, buf, len, false);
 		ustream_consume(s, len);
 	} while (1);


### PR DESCRIPTION
netifd gained ucode support on master, adapt the bind mounts so it works in a jail again.

While at it, the second patch disables the excessive uxc console logging.

/cc @dangowrt @aparcar 

Related question:
With a self-built image from the main branch my veth setup doesn't come up automatically, I have to run `ubus call network.interface.virt0 up` first to make it work. Is that my setup or another difference between stable/main?