### PR TITLE
system.board improvements

### DIFF
--- a/system.c
+++ b/system.c
@@ -145,18 +145,20 @@ static int system_board(struct ubus_context *ctx, struct ubus_object *obj,
 			key = strtok(line, "\t:");
 			val = strtok(NULL, "\t\n");
 
-			if (!key || !val)
+			if (!key || !val || strlen(val) < 3)
 				continue;
+
+			val += 2;
 
 #ifdef __aarch64__
 			if (!strcasecmp(key, "CPU revision")) {
-				snprintf(line, sizeof(line), "ARMv8 Processor rev %lu", strtoul(val + 2, NULL, 16));
+				snprintf(line, sizeof(line), "ARMv8 Processor rev %lu", strtoul(val, NULL, 16));
 				blobmsg_add_string(&b, "system", line);
 				break;
 			}
 #elif __riscv
 			if (!strcasecmp(key, "isa")) {
-				snprintf(line, sizeof(line), "RISC-V (%s)", val + 2);
+				snprintf(line, sizeof(line), "RISC-V (%s)", val);
 				blobmsg_add_string(&b, "system", line);
 				break;
 			}
@@ -166,11 +168,11 @@ static int system_board(struct ubus_context *ctx, struct ubus_object *obj,
 			    !strcasecmp(key, "cpu") ||
 			    !strcasecmp(key, "model name"))
 			{
-				strtoul(val + 2, &key, 0);
+				strtoul(val, &key, 0);
 
-				if (key == (val + 2) || *key != 0)
+				if (key == (val) || *key != 0)
 				{
-					blobmsg_add_string(&b, "system", val + 2);
+					blobmsg_add_string(&b, "system", val);
 					break;
 				}
 			}
@@ -200,13 +202,15 @@ static int system_board(struct ubus_context *ctx, struct ubus_object *obj,
 			key = strtok(line, "\t:");
 			val = strtok(NULL, "\t\n");
 
-			if (!key || !val)
+			if (!key || !val || strlen(val) < 3)
 				continue;
+
+			val += 2;
 
 			if (!strcasecmp(key, "machine") ||
 			    !strcasecmp(key, "hardware"))
 			{
-				blobmsg_add_string(&b, "model", val + 2);
+				blobmsg_add_string(&b, "model", val);
 				break;
 			}
 		}

--- a/system.c
+++ b/system.c
@@ -158,6 +158,11 @@ static int system_board(struct ubus_context *ctx, struct ubus_object *obj,
 			}
 #elif __riscv
 			if (!strcasecmp(key, "isa")) {
+				char *tmp = val;
+				while (*tmp++)
+					if (*tmp == '_')
+						*tmp = ' ';
+
 				char buf[512];
 				snprintf(buf, sizeof(buf), "RISC-V (%s)", val);
 				blobmsg_add_string(&b, "system", buf);

--- a/system.c
+++ b/system.c
@@ -124,7 +124,7 @@ static int system_board(struct ubus_context *ctx, struct ubus_object *obj,
                  struct blob_attr *msg)
 {
 	void *c;
-	char line[256];
+	char line[512];
 	char *key, *val, *next;
 	const char *rootfs_type = system_rootfs_type();
 	struct utsname utsname;
@@ -158,8 +158,9 @@ static int system_board(struct ubus_context *ctx, struct ubus_object *obj,
 			}
 #elif __riscv
 			if (!strcasecmp(key, "isa")) {
-				snprintf(line, sizeof(line), "RISC-V (%s)", val);
-				blobmsg_add_string(&b, "system", line);
+				char buf[512];
+				snprintf(buf, sizeof(buf), "RISC-V (%s)", val);
+				blobmsg_add_string(&b, "system", buf);
 				break;
 			}
 #else


### PR DESCRIPTION
This is Just one cleanup patch, one fix and one improvement.

`ubus call system board`, "system" before:
`RISC-V (4imafdcv_zicbom_zicbop_zicboz_zicntr_zicond_zicsr_zifencei_zihintpause_zihpm_zaamo_zalrsc_zfh_zca_zcd_zba_zbb_zbc_zbs_zkt_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvkt_sscofpmf_sstc_svinval_svnapot_svpbmt`

after:
`RISC-V (rv64imafdcv zicbom zicbop zicboz zicntr zicond zicsr zifencei zihintpause zihpm zaamo zalrsc zfh zca zcd zba zbb zbc zbs zkt zve32f zve32x zve64d zve64f zve64x zvfh zvkt sscofpmf sstc svinval svnapot svpbmt)`