### PR TITLE
jail: don't let the jailed process outlive the jail

### DIFF
--- a/jail/jail.c
+++ b/jail/jail.c
@@ -21,6 +21,8 @@
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
+#include <sys/syscall.h>
+#include <poll.h>
 
 /* musl only defined 15 limit types, make sure all 16 are supported */
 #ifndef RLIMIT_RTTIME
@@ -1854,6 +1856,7 @@ static struct uloop_timeout pre_exec_timeout = {
 };
 
 int pipes[4];
+static int parent_pidfd = -1;
 static int exec_jail(void *arg)
 {
 	char buf[1];
@@ -2085,6 +2088,32 @@ static void post_start_hook(void)
 	if (opts.no_new_privs && prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
 		ERROR("prctl(PR_SET_NO_NEW_PRIVS) failed: %m\n");
 		free_and_exit(EXIT_FAILURE);
+	}
+
+	/* the supervisor can SIGKILL ujail on its own death (netifd on exit,
+	 * procd's instance_timeout() escalation); die with it, otherwise the
+	 * jailed process keeps running and the supervisor's supervisor starts
+	 * a second instance. Placed after set_jail_user() and the capability
+	 * transitions, whose commit_creds() would zero pdeath_signal, but before
+	 * the seccomp filter, which need not permit prctl() to reach execve(). */
+	if (prctl(PR_SET_PDEATHSIG, SIGKILL)) {
+		ERROR("prctl(PR_SET_PDEATHSIG) failed: %m\n");
+		free_and_exit(EXIT_FAILURE);
+	}
+
+	/* the parent can die between the fork() and the prctl above; the death
+	 * signal is then bound to the process we are reparented to and never
+	 * delivered, so detect the exit on the inherited pidfd and die ourselves.
+	 * getppid() == 1 cannot serve here: in a new PID namespace the parent is
+	 * not visible and getppid() reads 0 either way. */
+	if (parent_pidfd >= 0) {
+		struct pollfd pfd = { .fd = parent_pidfd, .events = POLLIN };
+
+		if (poll(&pfd, 1, 0) > 0) {
+			ERROR("parent died before PR_SET_PDEATHSIG\n");
+			free_and_exit(EXIT_FAILURE);
+		}
+		close(parent_pidfd);
 	}
 
 	char **envp = build_envp(opts.seccomp, opts.envp);
@@ -3787,6 +3816,8 @@ static void post_main(struct uloop_timeout *t)
 	if (pipe2(&userns_pipe[0], O_CLOEXEC) < 0 || pipe2(&userns_pipe[2], O_CLOEXEC) < 0)
 		free_and_exit(-1);
 
+	parent_pidfd = syscall(SYS_pidfd_open, getpid(), 0);
+
 	if (has_namespaces()) {
 		if (opts.namespace & CLONE_NEWNS) {
 			if (!opts.extroot && (opts.user || opts.group)) {
@@ -3928,6 +3959,7 @@ static void post_main(struct uloop_timeout *t)
 		/* parent process */
 		char sig_buf[1];
 
+		close(parent_pidfd);
 		uloop_process_add(&jail_process);
 		jail_running = 1;
 		if (seteuid(0)) {

--- a/jail/jail.c
+++ b/jail/jail.c
@@ -1795,8 +1795,8 @@ static void jail_process_handler(struct uloop_process *c, int ret)
 		jail_return_code = WEXITSTATUS(ret);
 		INFO("jail (%d) exited with exit: %d\n", c->pid, jail_return_code);
 	} else {
-		jail_return_code = WTERMSIG(ret);
-		INFO("jail (%d) exited with signal: %d\n", c->pid, jail_return_code);
+		jail_return_code = 128 + WTERMSIG(ret);
+		INFO("jail (%d) exited with signal: %d\n", c->pid, WTERMSIG(ret));
 	}
 	jail_running = 0;
 	poststop();


### PR DESCRIPTION
ujail forwards SIGTERM to the jailed process and escalates to SIGKILL after the
term timeout, but there is no equivalent for ujail itself being SIGKILLed: the
jailed process keeps running with nothing left that can stop it, and whoever
supervises ujail sees it exit and starts a second instance of the daemon.

Both of procd's own supervisors send that SIGKILL:

* `instance_timeout()` escalates to SIGKILL when an instance does not stop on
  SIGTERM (`service/instance.c`).
* netifd SIGKILLs every child in `netifd_kill_processes()` when it exits
  (`main.c`), which is reached on a plain `/etc/init.d/network restart` whenever
  a jailed proto handler has not finished tearing down within the one second the
  init script sleeps after `ifdown -a`.

`prctl(PR_SET_PDEATHSIG, SIGKILL)` in the child closes it. It is set right
before the `execve()`, after the user/group and capability transitions
(`set_jail_user()`, the userns `setreuid()`/`setregid()` and
`applyOCIcapabilities()` all clear the setting on credential change, so an
earlier placement silently no-ops for `-U`/`-G`/`-f` jails). Since the parent
can die between `fork()` and the `prctl`, the child checks `getppid()` and
self-terminates when the parent is already gone — the death signal would
otherwise be bound to init's death and never be delivered.

The second commit changes how a signal death of the jailed process is reported:
ujail exits with `128 + WTERMSIG` (the shell convention) instead of the bare
signal number. A supervisor that only reads `WEXITSTATUS` cannot tell a
signal-killed process from one that exited with the signal number as its code;
pppd's exit table collides head-on (`EXIT_PEER_AUTH_FAILED` is 9,
`EXIT_CONNECT_TIME` is 11), so a segfaulted pppd read as an auth failure and,
with `option authfail 1`, blocked the WAN link until manual intervention.

### Testing

On an ipq807x router with a PPPoE uplink, pppd wrapped in
`ujail -C … -c -- /usr/sbin/pppd …` and started by netifd:

| | `kill -9 <ujail>` |
|---|---|
| before | pppd survives; netifd starts a **second** pppd, two of them on one link |
| after | pppd is reaped with the jail; netifd restarts a single clean pair |

`hostapd`, `wpa_supplicant`, `ntpd` and `dnsmasq` jails start and stop normally
with the patched ujail, including the `-U`/`-G` user jails whose setting the
placement change is what makes survive.